### PR TITLE
Fix curated group summary text

### DIFF
--- a/GAMBMG.ps1
+++ b/GAMBMG.ps1
@@ -72,7 +72,7 @@ Email:		devin@burningman.org
 		
 Updates:
 	7/2/25 	Added additional add-user loop after group creation.
-		Added currated group summary after group creation, and if the group address already exists.
+                Added curated group summary after group creation, and if the group address already exists.
 	
 "@
     exit 0

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ If you run gambmg with no parameters, you will be prompted interactively.
 Updates:
 
 	7/2/25 	Added additional add-user loop after group creation.
-		Added currated group summary after group creation, and if the group address already exists.
+               Added **curated** group summary after group creation, and if the group address already exists.
   	7/2/25 	Added MacOS Bash Version in GAMBMG.sh


### PR DESCRIPTION
## Summary
- correct spelling for curated group summary in README
- update about section in PowerShell script to use curated wording

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e1e881ac832bab3452e319dc1af0