### PR TITLE
Fix bash compatibility and update docs

### DIFF
--- a/GAMBMG.sh
+++ b/GAMBMG.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Default path to GAM. Update if different on your system
-gam="gam"
+GAM_CMD="gam"
 
 usage() {
   cat <<USAGE
@@ -23,6 +23,10 @@ ABOUT
 }
 
 # Helpers
+to_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 Test_Exists() {
   local email="$1"
   if "$GAM_CMD" whatis "$email" 2>&1 | grep -Eq "Service not applicable|Entity does not exist"; then
@@ -60,7 +64,7 @@ Show_Group_Summary() {
 }
 
 Get_Template() {
-  case "${1,,}" in
+  case "$(to_lower "$1")" in
     a* ) echo "aliastemplate@burningman.org alias";;
     an* ) echo "announcetemplate@burningman.org announce";;
     d* ) echo "discussiontemplate@burningman.org discussion";;
@@ -86,9 +90,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 SHOULD_FORCE=false
-[[ ${FORCE,,} == y* ]] && SHOULD_FORCE=true
+[[ $(to_lower "$FORCE") == y* ]] && SHOULD_FORCE=true
 SHOULD_TEST=false
-[[ ${TESTMODE,,} == y* ]] && SHOULD_TEST=true
+[[ $(to_lower "$TESTMODE") == y* ]] && SHOULD_TEST=true
 
 # Interactive prompts for missing args
 if [[ -z $GROUP ]]; then
@@ -149,7 +153,7 @@ fi
 if [[ -z $MAILPREF ]]; then
   while :; do
     read -p "Should the owner receive mail from the group? [y/n] " resp
-    case ${resp,,} in
+    case $(to_lower "$resp") in
       y*) MAILPREF="allmail"; break;;
       n*) MAILPREF="nomail"; break;;
       *) echo "Please enter 'y' or 'n'.";;
@@ -179,7 +183,7 @@ echo "============================="
 if ! $SHOULD_FORCE; then
   while :; do
     read -p "DEPLOY AS PREVIEWED? [y/n] " conf
-    case ${conf,,} in
+    case $(to_lower "$conf") in
       y*) break;;
       n*) echo "Abort command received. No changes made."; exit 0;;
       *) echo "Please enter 'y' or 'n'.";;
@@ -200,7 +204,7 @@ if ! $SHOULD_TEST; then
     while ! $done; do
       read -p $'\nAdd additional users? [Y] Member / [O] Owner / [M] Manager / [N] No: ' opt
       role=""
-      case ${opt,,} in
+      case $(to_lower "$opt") in
         y*) role="member";;
         o*) role="owner";;
         m*) role="manager";;

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ mirrors the behaviour of the Windows PowerShell version but can be run
 directly from a standard Terminal. Ensure `gam` is installed and
 available on your `PATH` before running the script.
 
-	chmod +x <Path>
- 
- If you have permission errors when running gambmg
+       chmod +x <Path>
+
+If you receive a "Permission denied" error when running `gambmg`, ensure the
+script has execute permission by running `chmod +x /path/to/GAMBMG.sh`.
 
 ##Windows Usage
 


### PR DESCRIPTION
## Summary
- make GAMBMG.sh compatible with macOS bash 3.x
- clarify permission instructions in README

## Testing
- `bash -n GAMBMG.sh`


------
https://chatgpt.com/codex/tasks/task_e_6865e5910d18832b8bd9aa140a41e74c